### PR TITLE
pool[pretty-living-cow-74155j]: style errors and messages partials

### DIFF
--- a/beta-blog/app/controllers/articles_controller.rb
+++ b/beta-blog/app/controllers/articles_controller.rb
@@ -18,7 +18,7 @@ class ArticlesController < ApplicationController
         #render plain: params[:article].inspect
         @article = Article.new(article_params)
         if @article.save
-            flash[:notice] = "Article was successfully created"
+            flash[:success] = "Article was successfully created"
             redirect_to article_path(@article)
         else
             render 'new'
@@ -28,7 +28,7 @@ class ArticlesController < ApplicationController
     def update
         
         if @article.update(article_params)
-            flash[:notice] = "Article was successfully updated"
+            flash[:success] = "Article was successfully updated"
             redirect_to article_path(@article)
         else
             render 'edit'
@@ -42,7 +42,7 @@ class ArticlesController < ApplicationController
     def destroy
         
         @article.destroy
-        flash[:notice] = "Article was successfully deleted."
+        flash[:danger] = "Article was successfully deleted."
         redirect_to articles_path
     end
 

--- a/beta-blog/app/views/articles/_form.html.erb
+++ b/beta-blog/app/views/articles/_form.html.erb
@@ -1,6 +1,9 @@
 <% if @article.errors.any? %>
   <div class="row">
-    <div class="error">
+    <div class="panel panel-danger error">
+      <div class="panel-heading">
+        
+      </div>
       <h2>The following errors prevented the following Article from being created.</h2>
       <ul>
         <% @article.errors.full_messages.each do |msg| %>

--- a/beta-blog/app/views/articles/_form.html.erb
+++ b/beta-blog/app/views/articles/_form.html.erb
@@ -1,6 +1,6 @@
 <% if @article.errors.any? %>
   <div class="row">
-    <div class="col-xs-8 col-offset-2">
+    <div class="col-xs-8 col-xs-offset-2">
       <div class="panel panel-danger error">
         <div class="panel-heading">
           <h2 class="panel-title">

--- a/beta-blog/app/views/articles/_form.html.erb
+++ b/beta-blog/app/views/articles/_form.html.erb
@@ -1,17 +1,19 @@
 <% if @article.errors.any? %>
   <div class="row">
-    <div class="panel panel-danger error">
-      <div class="panel-heading">
-        <h2 class="panel-title">
-          <%= pluralize(@article.errors.count, "error") %>
-        </h2>
+    <div class="col-xs-8 col-offset-2">
+      <div class="panel panel-danger error">
+        <div class="panel-heading">
+          <h2 class="panel-title">
+            <%= pluralize(@article.errors.count, "error") %>
+          </h2>
+        </div>
+        <h2>The following errors prevented the following Article from being created.</h2>
+        <ul>
+          <% @article.errors.full_messages.each do |msg| %>
+            <li><%= msg %></li>
+          <% end %>
+        </ul>
       </div>
-      <h2>The following errors prevented the following Article from being created.</h2>
-      <ul>
-        <% @article.errors.full_messages.each do |msg| %>
-          <li><%= msg %></li>
-        <% end %>
-      </ul>
     </div>
   </div>
 <% end %>

--- a/beta-blog/app/views/articles/_form.html.erb
+++ b/beta-blog/app/views/articles/_form.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/errors' %>
+<%= render 'shared/errors', obj: @article %>
 <div class="row">
   <div class="col-xs-12">
     <%= form_for @article, :html => {class: "form-horizontal", role: "form"} do |f| %>

--- a/beta-blog/app/views/articles/_form.html.erb
+++ b/beta-blog/app/views/articles/_form.html.erb
@@ -2,7 +2,9 @@
   <div class="row">
     <div class="panel panel-danger error">
       <div class="panel-heading">
-        
+        <h2 class="panel-title">
+          <%= pluralize(@article.errors.count), "error" %>
+        </h2>
       </div>
       <h2>The following errors prevented the following Article from being created.</h2>
       <ul>

--- a/beta-blog/app/views/articles/_form.html.erb
+++ b/beta-blog/app/views/articles/_form.html.erb
@@ -1,24 +1,4 @@
-<% if @article.errors.any? %>
-  <div class="row">
-    <div class="col-xs-8 col-xs-offset-2">
-      <div class="panel panel-danger error">
-        <div class="panel-heading">
-          <h2 class="panel-title">
-            <%= pluralize(@article.errors.count, "error") %>
-            prevented the following Article from being created.
-          </h2>
-        </div>
-        <div class="panel-body">
-          <ul>
-            <% @article.errors.full_messages.each do |msg| %>
-              <li><%= msg %></li>
-            <% end %>
-          </ul>
-        </div>
-      </div>
-    </div>
-  </div>
-<% end %>
+<%= render 'shared/errors' %>
 <div class="row">
   <div class="col-xs-12">
     <%= form_for @article, :html => {class: "form-horizontal", role: "form"} do |f| %>

--- a/beta-blog/app/views/articles/_form.html.erb
+++ b/beta-blog/app/views/articles/_form.html.erb
@@ -5,14 +5,16 @@
         <div class="panel-heading">
           <h2 class="panel-title">
             <%= pluralize(@article.errors.count, "error") %>
+            prevented the following Article from being created.
           </h2>
         </div>
-        <h2>The following errors prevented the following Article from being created.</h2>
+        <div class="panel-body">
         <ul>
           <% @article.errors.full_messages.each do |msg| %>
             <li><%= msg %></li>
           <% end %>
         </ul>
+        </div>
       </div>
     </div>
   </div>

--- a/beta-blog/app/views/articles/_form.html.erb
+++ b/beta-blog/app/views/articles/_form.html.erb
@@ -3,7 +3,7 @@
     <div class="panel panel-danger error">
       <div class="panel-heading">
         <h2 class="panel-title">
-          <%= pluralize(@article.errors.count), "error" %>
+          <%= pluralize(@article.errors.count, "error") %>
         </h2>
       </div>
       <h2>The following errors prevented the following Article from being created.</h2>

--- a/beta-blog/app/views/articles/_form.html.erb
+++ b/beta-blog/app/views/articles/_form.html.erb
@@ -9,11 +9,11 @@
           </h2>
         </div>
         <div class="panel-body">
-        <ul>
-          <% @article.errors.full_messages.each do |msg| %>
-            <li><%= msg %></li>
-          <% end %>
-        </ul>
+          <ul>
+            <% @article.errors.full_messages.each do |msg| %>
+              <li><%= msg %></li>
+            <% end %>
+          </ul>
         </div>
       </div>
     </div>

--- a/beta-blog/app/views/layouts/_messages.html.erb
+++ b/beta-blog/app/views/layouts/_messages.html.erb
@@ -1,5 +1,9 @@
-<% flash.each do |name,msg| %>
-    <ul>
-        <li><%= msg %></li>
-    </ul>
-<% end %>
+<div class="row">
+    <div class="col-xs-10 col-xs-offset-1">
+        <% flash.each do |name,msg| %>
+            <ul>
+                <li><%= msg %></li>
+            </ul>
+        <% end %>
+    </div>
+</div>

--- a/beta-blog/app/views/layouts/_messages.html.erb
+++ b/beta-blog/app/views/layouts/_messages.html.erb
@@ -3,7 +3,7 @@
         <% flash.each do |name,msg| %>
             <div class='alert alert-<%="#{name}"%>'>
                 <a href="#" class="close" data-dismiss="alert">&#215;</a>
-                <%= content_tag :div, msg, :id => "flash_#{name}" if msg.is_a(String) %>
+                <%= content_tag :div, msg, :id => "flash_#{name}" if msg.is_a?(String) %>
             </div>
         <% end %>
     </div>

--- a/beta-blog/app/views/layouts/_messages.html.erb
+++ b/beta-blog/app/views/layouts/_messages.html.erb
@@ -3,6 +3,7 @@
         <% flash.each do |name,msg| %>
             <div class='alert alert-<%="#{name}"%>'>
                 <a href="#" class="close" data-dismiss="alert">&#215;</a>
+                <%= content_tag :div, msg, :id => "flash_#{name}" if msg.is_a(String) %>
                 <ul>
                     <li><%= msg %></li>
                 </ul>

--- a/beta-blog/app/views/layouts/_messages.html.erb
+++ b/beta-blog/app/views/layouts/_messages.html.erb
@@ -4,9 +4,6 @@
             <div class='alert alert-<%="#{name}"%>'>
                 <a href="#" class="close" data-dismiss="alert">&#215;</a>
                 <%= content_tag :div, msg, :id => "flash_#{name}" if msg.is_a(String) %>
-                <ul>
-                    <li><%= msg %></li>
-                </ul>
             </div>
         <% end %>
     </div>

--- a/beta-blog/app/views/layouts/_messages.html.erb
+++ b/beta-blog/app/views/layouts/_messages.html.erb
@@ -1,9 +1,11 @@
 <div class="row">
     <div class="col-xs-10 col-xs-offset-1">
         <% flash.each do |name,msg| %>
-            <ul>
-                <li><%= msg %></li>
-            </ul>
+            <div class='alert alert-<%="#{name}"%>'>
+                <ul>
+                    <li><%= msg %></li>
+                </ul>
+            </div>
         <% end %>
     </div>
 </div>

--- a/beta-blog/app/views/layouts/_messages.html.erb
+++ b/beta-blog/app/views/layouts/_messages.html.erb
@@ -2,6 +2,7 @@
     <div class="col-xs-10 col-xs-offset-1">
         <% flash.each do |name,msg| %>
             <div class='alert alert-<%="#{name}"%>'>
+                <a href="#" class="close" data-dismiss="alert">&#215;</a>
                 <ul>
                     <li><%= msg %></li>
                 </ul>

--- a/beta-blog/app/views/shared/_errors.html.erb
+++ b/beta-blog/app/views/shared/_errors.html.erb
@@ -1,16 +1,16 @@
-<% if @article.errors.any? %>
+<% if obj.errors.any? %>
   <div class="row">
     <div class="col-xs-8 col-xs-offset-2">
       <div class="panel panel-danger error">
         <div class="panel-heading">
           <h2 class="panel-title">
-            <%= pluralize(@article.errors.count, "error") %>
+            <%= pluralize(obj.errors.count, "error") %>
             prevented the following Article from being created.
           </h2>
         </div>
         <div class="panel-body">
           <ul>
-            <% @article.errors.full_messages.each do |msg| %>
+            <% obj.errors.full_messages.each do |msg| %>
               <li><%= msg %></li>
             <% end %>
           </ul>

--- a/beta-blog/app/views/shared/_errors.html.erb
+++ b/beta-blog/app/views/shared/_errors.html.erb
@@ -1,0 +1,21 @@
+<% if @article.errors.any? %>
+  <div class="row">
+    <div class="col-xs-8 col-xs-offset-2">
+      <div class="panel panel-danger error">
+        <div class="panel-heading">
+          <h2 class="panel-title">
+            <%= pluralize(@article.errors.count, "error") %>
+            prevented the following Article from being created.
+          </h2>
+        </div>
+        <div class="panel-body">
+          <ul>
+            <% @article.errors.full_messages.each do |msg| %>
+              <li><%= msg %></li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/why_commit.txt
+++ b/why_commit.txt
@@ -26,3 +26,4 @@
 05/01/2018 19:55:pool[rapid-living-mountain-17vt20]: style form partial
 05/01/2018 19:59:pool[pretty-rolling-mountain-56p6jj]: begin styling of error messages/notifications
 05/01/2018 21:26:pool[pretty-living-cow-v70c55]: continue add styling to header partial and some placeholder text to home page
+06/01/2018 14:29:pool[pretty-living-cow-74155j]: style errors and messages partials


### PR DESCRIPTION
* finish styling of errors within form partial with bootstrap panel
* create shared folder under views
* relocate errors from form to its own partial
* change @article reference to generic obj
* change flash[:notice] to reflect type of notice, such as :success or :danger